### PR TITLE
fixes unnecessary rebuilds of docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
   - "3.6"
+dist: xenial
 
 services:
   - docker

--- a/local.yml
+++ b/local.yml
@@ -26,8 +26,8 @@ services:
     command: /usr/src/app/entrypoint
 
   postgresql:
-    build:
     image: setlistspy_psql
+    build:
       context: .
       dockerfile: compose/local/postgres/Dockerfile
     volumes:

--- a/local.yml
+++ b/local.yml
@@ -2,10 +2,10 @@ version: "3.1"
 
 services:
   app: &app
+    image: setlistspy_api
     build:
       context: .
       dockerfile: ./compose/local/django/Dockerfile
-    image: setlistspy_local_django
     depends_on:
       - postgresql
       - redis
@@ -27,6 +27,7 @@ services:
 
   postgresql:
     build:
+    image: setlistspy_psql
       context: .
       dockerfile: compose/local/postgres/Dockerfile
     volumes:
@@ -41,23 +42,27 @@ services:
     expose:
     - "6379"
 
-  celery-worker:
-    <<: *app
-    image: setlistspy_local_celeryworker
+  celery-worker: &celery-worker
+    image: setlistspy_api
     depends_on:
       - redis
       - postgresql
+    links:
+      - phantomjs
+      - postgresql
+      - redis
+    env_file:
+      - ./.envs/.local/.django
+      - ./.envs/.local/.postgres
+    restart: on-failure
+    volumes:
+      - ./setlistspy:/usr/src/app/setlistspy
+      - ./lib:/usr/src/app/lib
     ports: []
     command: /start-celeryworker
 
   celery-beat:
-    <<: *app
-    image: setlistspy_local_celerybeat
-    depends_on:
-      - redis
-      - postgresql
-
-    ports: []
+    <<: *celery-worker
     command: /start-celerybeat
 
   flower:

--- a/production.yml
+++ b/production.yml
@@ -40,30 +40,35 @@ services:
     expose:
     - "6379"
 
-  celery-worker:
-    <<: *app
-    image: setlistspy_production_celeryworker
+  celery-worker: &celery-worker
+    image: setlistspy_api
     depends_on:
       - redis
+      - postgresql
+    links:
+      - phantomjs
+      - postgresql
+      - redis
+    env_file:
+      - ./.envs/.production/.django
+      - ./.envs/.production/.postgres
+    restart: on-failure
+    volumes:
+      - .:/app
     ports: []
-    command: ./start-celeryworker
+    command: /start-celeryworker
 
   celery-beat:
-    <<: *app
-    image: setlistspy_production_celerybeat
+    <<: *celery-worker
+    command: /start-celerybeat
+
+  flower:
+    image: mher/flower
     depends_on:
-      - redis
-
-    ports: []
-    command: ./start-celerybeat
-
-#  flower:
-#    image: mher/flower
-#    depends_on:
-#      - celery-worker
-#    command: celery flower --app=setlistspy.taskapp --broker="${REDIS_URL}" --basic_auth="${CELERY_FLOWER_USER}:${CELERY_FLOWER_PASSWORD}"
-#    ports:
-#      - "5555:5555"
+      - celery-worker
+    command: celery flower --app=setlistspy.taskapp --broker="${REDIS_URL}" --basic_auth="${CELERY_FLOWER_USER}:${CELERY_FLOWER_PASSWORD}"
+    ports:
+      - "5555:5555"
 
   phantomjs:
     image: codeclou/docker-phantomjs-webdriver-standalone:latest


### PR DESCRIPTION
fixes #10 -- now the docker image built for the django app should not be rebuilt for the celery worker & beat services